### PR TITLE
fix(package): update to latest ggit

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "bluebird": "3.1.1",
     "check-more-types": "2.10.0",
     "debug": "2.2.0",
-    "ggit": "1.8.1",
+    "ggit": "1.10.0",
     "lazy-ass": "1.3.0",
     "pluralize": "1.2.1",
     "ramda": "0.19.1",


### PR DESCRIPTION
this package fails an nsp check because of the old `ggit` dep.