### PR TITLE
Use object shorthand for properties

### DIFF
--- a/src/rule-to-tester.js
+++ b/src/rule-to-tester.js
@@ -19,7 +19,7 @@ function extension (filename) {
 
 const fileParts = {
   filename: path.basename,
-  extension: extension,
+  extension,
   path: I
 }
 


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

compatibility: The syntax is compatible with Node.js 4.x, and supported where arrow functions are, which are already used in this project.